### PR TITLE
Add CBOR decoding functions for parametrized scripts

### DIFF
--- a/src/PlutusAppsExtra/Utils/Scripts.hs
+++ b/src/PlutusAppsExtra/Utils/Scripts.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
+
 module PlutusAppsExtra.Utils.Scripts where
 
 import qualified Codec.CBOR.Decoding   as CBOR
@@ -8,8 +10,10 @@ import qualified Data.ByteString.Short as SBS
 import           Data.Coerce           (coerce)
 import qualified Flat
 import qualified Flat.Decoder          as Flat
-import           Ledger                (MintingPolicy (..), Script (..), Validator (..))
+import           Ledger                (MintingPolicy (..), Script (..), Validator (..), mkMintingPolicyScript, mkValidatorScript)
 import           PlutusCore            (DefaultFun, DefaultUni)
+import qualified PlutusTx
+import           PlutusTx.Code         (CompiledCode)
 import           Text.Hex              (Text, decodeHex, encodeHex)
 import qualified UntypedPlutusCore     as UPLC
 
@@ -19,13 +23,25 @@ validatorToCBOR = encodeHex . SBS.fromShort . serialiseUPLC . coerce
 validatorFromCBOR :: Text -> Maybe Validator
 validatorFromCBOR = fmap (coerce . deserialiseUPLC . SBS.toShort) . decodeHex
 
+parametrizedValidatorFromCBOR :: PlutusTx.Lift DefaultUni a => Text -> Maybe (a -> Validator)
+parametrizedValidatorFromCBOR txt = fmap mkValidatorScript <$> parametrizedCompiledCodeFromCBOR txt
+
 mintingPolicyToCBOR :: MintingPolicy -> Text
 mintingPolicyToCBOR = encodeHex . SBS.fromShort . serialiseUPLC . coerce
 
 mintingPolicyFromCBOR :: Text -> Maybe MintingPolicy
 mintingPolicyFromCBOR = fmap (coerce . deserialiseUPLC . SBS.toShort) . decodeHex
 
+parametrizedMintingPolicyFromCBOR :: PlutusTx.Lift DefaultUni a => Text -> Maybe (a -> MintingPolicy)
+parametrizedMintingPolicyFromCBOR txt = fmap mkMintingPolicyScript <$> parametrizedCompiledCodeFromCBOR txt
+
 type SerialisedScript = ShortByteString
+
+parametrizedCompiledCodeFromCBOR :: PlutusTx.Lift DefaultUni par => Text -> Maybe (par -> PlutusTx.CompiledCodeIn DefaultUni DefaultFun x)
+parametrizedCompiledCodeFromCBOR txt = do
+    bs <- decodeHex txt
+    let code = deserialiseCompiledCode $ SBS.toShort bs
+    pure $ \a -> code `PlutusTx.applyCode` PlutusTx.liftCode a
 
 serialiseUPLC :: UPLC.Program UPLC.DeBruijn DefaultUni DefaultFun () -> SerialisedScript
 serialiseUPLC =
@@ -38,6 +54,11 @@ serialiseUPLC =
 deserialiseUPLC :: SerialisedScript -> UPLC.Program UPLC.DeBruijn DefaultUni DefaultFun ()
 deserialiseUPLC = unSerialiseViaFlat . deserialise . LBS.fromStrict . SBS.fromShort
     where
+        unSerialiseViaFlat (SerialiseViaFlat a) = a
+
+deserialiseCompiledCode :: SerialisedScript -> CompiledCode a
+deserialiseCompiledCode = unSerialiseViaFlat . deserialise . LBS.fromStrict . SBS.fromShort
+     where
         unSerialiseViaFlat (SerialiseViaFlat a) = a
 
 -- | Newtype to provide 'Serialise' instances for types with a 'Flat' instance that


### PR DESCRIPTION
Add functions for decoding text into validator/minting policy that depends on an additional parameter.